### PR TITLE
Add shebang parsing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,6 @@ omit =
 
 [report]
 show_missing = True
-skip_covered = True
 
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/identify/identify.py
+++ b/identify/identify.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import io
+import os
+import shlex
+import string
+
+
+printable = frozenset(string.printable)
+
+
+def parse_shebang(bytesio):
+    """Parse the shebang from a file opened for reading binary."""
+    if bytesio.read(2) != b'#!':
+        return ()
+    first_line = bytesio.readline()
+    try:
+        first_line = first_line.decode('US-ASCII')
+    except UnicodeDecodeError:
+        return ()
+
+    # Require only printable ascii
+    for c in first_line:
+        if c not in printable:
+            return ()
+
+    cmd = tuple(shlex.split(first_line))
+    if cmd[0] == '/usr/bin/env':
+        cmd = cmd[1:]
+    return cmd
+
+
+def parse_shebang_from_file(path):
+    """Parse the shebang given a file path."""
+    if not os.path.exists(path) or not os.access(path, os.X_OK):
+        return ()
+
+    with io.open(path, 'rb') as f:
+        return parse_shebang(f)

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import io
+import os
+import stat
+
+import pytest
+
+from identify import identify
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        (b'', ()),
+        (b'#!/usr/bin/python', ('/usr/bin/python',)),
+        (b'#!/usr/bin/env python', ('python',)),
+        (b'#! /usr/bin/python', ('/usr/bin/python',)),
+        (b'#!/usr/bin/foo  python', ('/usr/bin/foo', 'python')),
+        (b'\xf9\x93\x01\x42\xcd', ()),
+        (b'#!\xf9\x93\x01\x42\xcd', ()),
+        (b'#!\x00\x00\x00\x00', ()),
+    ),
+)
+def test_parse_bytesio(s, expected):
+    assert identify.parse_shebang(io.BytesIO(s)) == expected
+
+
+def test_file_doesnt_exist():
+    assert identify.parse_shebang_from_file('herp derp derp') == ()
+
+
+def test_file_not_executable(tmpdir):
+    x = tmpdir.join('f')
+    x.write_text('#!/usr/bin/env python', encoding='UTF-8')
+    assert identify.parse_shebang_from_file(x.strpath) == ()
+
+
+def test_simple_case(tmpdir):
+    x = tmpdir.join('f')
+    x.write_text('#!/usr/bin/env python', encoding='UTF-8')
+    make_executable(x.strpath)
+    assert identify.parse_shebang_from_file(x.strpath) == ('python',)
+
+
+def make_executable(filename):
+    original_mode = os.stat(filename).st_mode
+    os.chmod(
+        filename,
+        original_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH,
+    )


### PR DESCRIPTION
This is almost an exact copy-paste from pre-commit:
https://github.com/pre-commit/pre-commit/blob/master/pre_commit/util.py

It kinda sucks that it's `identify.identify`. All of the code could fit in one module, but we're probably going to want the mappings from extension to tags and interpreter to tags to go in separate modules, so I made this a package.

Should I move this code to `identify/__init__.py` so you can still `import identify` instead of `from identify import identify`? That seems kinda sneaky.