### PR TITLE
Update venv target for new tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ minimal: venv
 
 .PHONY: venv
 venv: .venv.touch
-	tox -e venv $(REBUILD_FLAG)
+	tox --notest -e venv $(REBUILD_FLAG)
 
 .PHONY: test
 test: .venv.tox.touch

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ commands =
 [testenv:venv]
 basepython = /usr/bin/python3.5
 envdir = venv
-commands =
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
Otherwise on stretch (tox `2.5.0`) it complains with:

```
ckuehl@raziel:~/proj/identify$ make venv
tox -e venv
GLOB sdist-make: /srv/data/home/ckuehl/proj/identify/setup.py
venv create: /srv/data/home/ckuehl/proj/identify/venv
venv installdeps: -rrequirements-dev.txt
venv inst: /srv/data/home/ckuehl/proj/identify/.tox/dist/identify-0.0.2.zip
venv installed: appdirs==1.4.0,aspy.yaml==0.2.2,cached-property==1.3.0,coverage==4.3.4,identify==0.0.2,jsonschema==2.6.0,nodeenv==1.1.2,packaging==16.8,pkg-resources==0.0.0,pre-commit==0.13.2,py==1.4.32,pytest==3.0.6,PyYAML==3.12,six==1.10.0,virtualenv==15.1.0
ERROR: Commands not specified. Please update relevant section of /srv/data/home/ckuehl/proj/identify/tox.ini
________________ summary ______________
ERROR:   venv: nothing to do
Makefile:8: recipe for target 'venv' failed
make: *** [venv] Error 1
```

I also confirmed this works on yelpy tox2 (2.1.1) when changing tox => tox2 in the Makefile.