### PR TITLE
Add .wsgi extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -117,6 +117,7 @@ EXTENSIONS = {
     'whl': {'binary', 'wheel', 'zip'},
     'woff': {'binary', 'woff'},
     'woff2': {'binary', 'woff2'},
+    'wsgi': {'text', 'wsgi', 'python'},
     'xml': {'text', 'xml'},
     'yaml': {'text', 'yaml'},
     'yml': {'text', 'yaml'},


### PR DESCRIPTION
For python wsgi applications it's relatively common to list your entrypoint in a `.wsgi` file