### PR TITLE
Add yamllint configuration to extensions

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -148,6 +148,7 @@ NAMES = {
     '.jshintrc': {'text', 'json', 'jshintrc'},
     '.mailmap': {'text', 'mailmap'},
     '.npmignore': {'text', 'npmignore'},
+    '.yamllint': {'text', 'yaml', 'yamllint'},
     'AUTHORS': EXTENSIONS['txt'],
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},


### PR DESCRIPTION
Refer-to: Configuration — yamllint 1.11.1 documentation <https://yamllint.readthedocs.io/en/stable/configuration.html>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>