### PR TITLE
Add .cu extension for cuda

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -12,6 +12,7 @@ EXTENSIONS = {
     'bz2': {'binary', 'bzip2'},
     'c': {'text', 'c'},
     'cc': {'text', 'c++'},
+    'cu': {'text', 'cuda'},
     'cfg': {'text'},
     'cmake': {'text', 'cmake'},
     'cnf': {'text'},


### PR DESCRIPTION
Intentionally excluded C because CUDA C has some additional syntax.