### PR TITLE
Identify .j2 extension as jinja2

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -57,6 +57,7 @@ EXTENSIONS = {
     'idl': {'text', 'idl'},
     'inc': {'text', 'inc'},
     'ini': {'text', 'ini'},
+    'j2': {'text', 'jinja'},
     'jade': {'text', 'jade'},
     'jar': {'binary', 'zip', 'jar'},
     'java': {'text', 'java'},


### PR DESCRIPTION
Ansible uses .j2 as the de-facto extension for Jinja templates.  This change identifies .j2 files as jinja. 