### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,11 +12,6 @@ commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 
-[testenv:venv]
-basepython = /usr/bin/python3.6
-envdir = venv
-commands =
-
 [flake8]
 max-line-length = 119
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos