### PR TITLE
Identify CMakeLists.txt as cmake file

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -189,6 +189,7 @@ NAMES = {
     '.npmignore': {'text', 'npmignore'},
     '.yamllint': {'text', 'yaml', 'yamllint'},
     'AUTHORS': EXTENSIONS['txt'],
+    'CMakeLists.txt': EXTENSIONS['cmake'],
     'COPYING': EXTENSIONS['txt'],
     'Dockerfile': {'text', 'dockerfile'},
     'Gemfile': EXTENSIONS['rb'],


### PR DESCRIPTION
Currently, CMakeLists.txt files are identified as plain text files because of their .txt extension.
Instead they should be tagged with `cmake`.