### PR TITLE
Handle malformed shebangs

### DIFF
--- a/identify/identify.py
+++ b/identify/identify.py
@@ -157,7 +157,7 @@ def parse_shebang(bytesio):
             return ()
 
     cmd = tuple(_shebang_split(first_line.strip()))
-    if cmd[0] == '/usr/bin/env':
+    if cmd and cmd[0] == '/usr/bin/env':
         cmd = cmd[1:]
     return cmd
 

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -54,6 +54,15 @@ def test_tags_from_path_simple_file(tmpdir):
     }
 
 
+def test_tags_from_path_file_with_incomplete_shebang(tmpdir):
+    x = tmpdir.join('test')
+    x.write_text('#!   \n', encoding='UTF-8')
+    make_executable(x.strpath)
+    assert identify.tags_from_path(x.strpath) == {
+        'file', 'text', 'executable',
+    }
+
+
 def test_tags_from_path_file_with_shebang_non_executable(tmpdir):
     x = tmpdir.join('test')
     x.write_text('#!/usr/bin/env python\nimport sys\n', encoding='UTF-8')


### PR DESCRIPTION
One of the tests in valgrind specifically provides a shebang that is
malformed (contains just a `#!`), which is technically valid bourne
shell syntax.

Fix the code to check that the result from `shlex.split(..)` isn't an
empty `tuple` to avoid an `IndexError` traceback when malformed input
is provided to `identify`.

Add a testcase for the issue.