### PR TITLE
feat: add adoc/asciidoc file extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 
 
 EXTENSIONS = {
+    'adoc': {'text', 'asciidoc'},
+    'asciidoc': {'text', 'asciidoc'},
     'apinotes': {'text', 'apinotes'},
     'asar': {'binary', 'asar'},
     'bash': {'text', 'shell', 'bash'},


### PR DESCRIPTION
The list of conventional AsciiDoc extensions is found here:
https://asciidoctor.org/docs/asciidoc-recommended-practices/#document-extension

Although GitHub supports a file extension of `.asc`, the reference above advises against using it due to collisions with other file types:

> We strongly recommend against using the .asc extension. The connection to AsciiDoc isn’t immediately obvious and it gets falsely identified as a PGP file on Linux. 
