### PR TITLE
support whatever.BUILD bazel files

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -206,6 +206,7 @@ NAMES = {
     '.yamllint': EXTENSIONS['yaml'] | {'yamllint'},
     '.zshrc': EXTENSIONS['zsh'],
     'AUTHORS': EXTENSIONS['txt'],
+    '.BUILD': {'text', 'bazel'},
     'BUILD.bazel': {'text', 'bazel'},
     'BUILD': {'text', 'bazel'},
     'CMakeLists.txt': EXTENSIONS['cmake'],


### PR DESCRIPTION
It's common for external bazel workspaces to use `external-project.BUILD` files, as opposed to `BUILD.bazel` files typically present in bazel projects. This is to differentiate them from the local workspace's bazel files, which have the format `BUILD` or `BUILD.bazel`. Hence, it would be good to treat these files like bazel files as well.