### PR TITLE
Add Ocaml files to the list

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -88,6 +88,8 @@ EXTENSIONS = {
     'md': {'text', 'markdown'},
     'mib': {'text', 'mib'},
     'mk': {'text', 'makefile'},
+    'ml': {'text', 'ocaml'},
+    'mli': {'text', 'ocaml'},
     'mm': {'text', 'c++', 'objective-c++'},
     'modulemap': {'text', 'modulemap'},
     'ngdoc': {'text', 'ngdoc'},


### PR DESCRIPTION
.ml / .mli is the OCaml equivalent of .c / .h in C.