### PR TITLE
Add extension for .graphql schema

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -48,6 +48,7 @@ EXTENSIONS = {
     'go': {'text', 'go'},
     'gotmpl': {'text', 'gotmpl'},
     'gpx': {'text', 'gpx', 'xml'},
+    'graphql': {'text', 'graphql'},
     'gradle': {'text', 'groovy'},
     'groovy': {'text', 'groovy'},
     'gyb': {'text', 'gyb'},


### PR DESCRIPTION
.graphql files are text files describing an interface with a bespoke IDL described in the spec at https://spec.graphql.org/June2018/