### PR TITLE
Add gd extension for GDScript from Godot

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -45,6 +45,7 @@ EXTENSIONS = {
     'eyaml': {'text', 'yaml'},
     'feature': {'text', 'gherkin'},
     'fish': {'text', 'fish'},
+    'gd': {'text', 'gdscript'},
     'gemspec': {'text', 'ruby'},
     'gif': {'binary', 'image', 'gif'},
     'go': {'text', 'go'},


### PR DESCRIPTION
Add the extension for the GDScript code source files of https://github.com/godotengine/godot

https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/gdscript_basics.html

GDScript is a language strongly inspired by python.

Godot project has 32.5k :star:  on github.