### PR TITLE
Add 'inx'->'xml' to 'extensions.py'

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -71,6 +71,7 @@ EXTENSIONS = {
     'idr': {'text', 'idris'},
     'inc': {'text', 'inc'},
     'ini': {'text', 'ini'},
+    'inx': {'text', 'xml', 'inx'},
     'ipynb': {'text', 'jupyter'},
     'j2': {'text', 'jinja'},
     'jade': {'text', 'jade'},


### PR DESCRIPTION
See #120 
`inx` is an `xml` file used by Incscape and Adobe InDesign