### PR TITLE
Add 'xml' type to 'svg' extension

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -155,7 +155,7 @@ EXTENSIONS = {
     'styl': {'text', 'stylus'},
     'sql': {'text', 'sql'},
     'sv': {'text', 'system-verilog'},
-    'svg': {'text', 'image', 'svg'},
+    'svg': {'text', 'image', 'svg', 'xml'},
     'svh': {'text', 'system-verilog'},
     'swf': {'binary', 'swf'},
     'swift': {'text', 'swift'},


### PR DESCRIPTION
SVG is an XML-based vector image format (cf. [wikipedia](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics))

I hope it is okay that I skipped making an issue before opening this PR.