### PR TITLE
Add libsonnet extension as jsonnet

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -91,6 +91,7 @@ EXTENSIONS = {
     'kt': {'text', 'kotlin'},
     'less': {'text', 'less'},
     'lhs': {'text', 'literate-haskell'},
+    'libsonnet': {'text', 'jsonnet'},
     'lidr': {'text', 'idris'},
     'lua': {'text', 'lua'},
     'm': {'text', 'c', 'objective-c'},


### PR DESCRIPTION
Per https://jsonnet.org/learning/tutorial.html:
"Files designed for import by convention end with .libsonnet"