### PR TITLE
add: interpreters

### DIFF
--- a/identify/interpreters.py
+++ b/identify/interpreters.py
@@ -3,9 +3,14 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 INTERPRETERS = {
+    'ash': {'shell', 'ash'},
+    'awk': {'awk'},
     'bash': {'shell', 'bash'},
+    'bats': {'shell', 'bash', 'bats'},
     'csh': {'shell', 'csh'},
     'dash': {'shell', 'dash'},
+    'expect': {'expect'},
+    'ksh': {'shell', 'ksh'},
     'node': {'javascript'},
     'nodejs': {'javascript'},
     'perl': {'perl'},


### PR DESCRIPTION
the lest known might be: https://linux.die.net/man/1/expect

This is needed downstream to better catching supported vs non-supported shells for  `shellcheck` : see https://github.com/cachix/pre-commit-hooks.nix/pull/63#issuecomment-687236558

I didn't bother adding corresponding file extensions, since:
- I don't know them for sure
- The vast majority of cases will probably be covered by this
- If there is need & knowledge, I suggest to add them individually