### PR TITLE
imp: add nix-shell interpreter parser

### DIFF
--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -219,57 +219,61 @@ def test_file_is_text_does_not_exist(tmpdir):
         (b"#! /path'with/quotes y ", ("/path'with/quotes", 'y')),
         # Test nix-shell specialites with shebang on second line
         (
-            b'#! /usr/bin/env nix-shell\n' +
+            b'#! /usr/bin/env nix-shell\n'
             b'#! nix-shell -i bash -p python',
             ('bash',),
         ),
         (
-            b'#! /usr/bin/env nix-shell\n' +
+            b'#! /usr/bin/env nix-shell\n'
             b'#! nix-shell -i python -p coreutils',
             ('python',),
         ),
         (
-            b'#! /usr/bin/env nix-shell\n' +
+            b'#! /usr/bin/env nix-shell\n'
             b'#! nix-shell -p coreutils -i python',
             ('python',),
         ),
         # multi-line and no whitespace variation
         (
-            b'#! /usr/bin/env nix-shell\n' +
-            b'#! nix-shell -p coreutils\n' +
+            b'#! /usr/bin/env nix-shell\n'
+            b'#! nix-shell -p coreutils\n'
             b'#! nix-shell -i python',
             ('python',),
         ),
         (
-            b'#! /usr/bin/env nix-shell\n' +
-            b'#!nix-shell -p coreutils\n' +
+            b'#! /usr/bin/env nix-shell\n'
+            b'#!nix-shell -p coreutils\n'
             b'#!nix-shell -i python',
             ('python',),
         ),
         (
-            b'#! /usr/bin/env nix-shell\n' +
+            b'#! /usr/bin/env nix-shell\n'
             b'#!\xf9\x93\x01\x42\xcd',
-            (),
+            ('nix-shell',),
         ),
         (
-            b'#! /usr/bin/env nix-shell\n' +
+            b'#! /usr/bin/env nix-shell\n'
             b'#!\x00\x00\x00\x00',
-            (),
+            ('nix-shell',),
         ),
         # non-proper nix-shell
-        # (b'#! /usr/bin/nix-shell', ()),  # out of scope test
-        (b'#! /usr/bin/env nix-shell', ()),
-        (b'#! /usr/bin/env nix-shell non-portable-argument', ()),
+        (b'#! /usr/bin/nix-shell', ('/usr/bin/nix-shell',)),
+        (b'#! /usr/bin/env nix-shell', ('nix-shell',)),
         (
-            b'#! /usr/bin/env nix-shell\n' +
-            b'#! nix-shell -i', (),   # guard against index error
+            b'#! /usr/bin/env nix-shell non-portable-argument',
+            ('nix-shell', 'non-portable-argument'),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n'
+            b'#! nix-shell -i',
+            ('nix-shell',),   # guard against index error
         ),
         # interpret quotes correctly
         (
-            b'#!/usr/bin/env nix-shell\n' +
-            b'#!nix-shell --argstr x "a -i python3 p"\n' +
-            b'#!nix-shell -p hello\n' +
-            b'#!nix-shell -i bash\n' +
+            b'#!/usr/bin/env nix-shell\n'
+            b'#!nix-shell --argstr x "a -i python3 p"\n'
+            b'#!nix-shell -p hello\n'
+            b'#!nix-shell -i bash\n'
             b'#!nix-shell --argstr y "b -i runhaskell q"',
             ('bash',),
         ),

--- a/tests/identify_test.py
+++ b/tests/identify_test.py
@@ -217,6 +217,62 @@ def test_file_is_text_does_not_exist(tmpdir):
         (b"#!/path'with/quotes    y", ("/path'with/quotes", 'y')),
         # Don't regress on leading/trailing ws
         (b"#! /path'with/quotes y ", ("/path'with/quotes", 'y')),
+        # Test nix-shell specialites with shebang on second line
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#! nix-shell -i bash -p python',
+            ('bash',),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#! nix-shell -i python -p coreutils',
+            ('python',),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#! nix-shell -p coreutils -i python',
+            ('python',),
+        ),
+        # multi-line and no whitespace variation
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#! nix-shell -p coreutils\n' +
+            b'#! nix-shell -i python',
+            ('python',),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#!nix-shell -p coreutils\n' +
+            b'#!nix-shell -i python',
+            ('python',),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#!\xf9\x93\x01\x42\xcd',
+            (),
+        ),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#!\x00\x00\x00\x00',
+            (),
+        ),
+        # non-proper nix-shell
+        # (b'#! /usr/bin/nix-shell', ()),  # out of scope test
+        (b'#! /usr/bin/env nix-shell', ()),
+        (b'#! /usr/bin/env nix-shell non-portable-argument', ()),
+        (
+            b'#! /usr/bin/env nix-shell\n' +
+            b'#! nix-shell -i', (),   # guard against index error
+        ),
+        # interpret quotes correctly
+        (
+            b'#!/usr/bin/env nix-shell\n' +
+            b'#!nix-shell --argstr x "a -i python3 p"\n' +
+            b'#!nix-shell -p hello\n' +
+            b'#!nix-shell -i bash\n' +
+            b'#!nix-shell --argstr y "b -i runhaskell q"',
+            ('bash',),
+        ),
         (b'\xf9\x93\x01\x42\xcd', ()),
         (b'#!\xf9\x93\x01\x42\xcd', ()),
         (b'#!\x00\x00\x00\x00', ()),


### PR DESCRIPTION
nix-shell uses the second line to pass relevant arguments
to the interpreter. Linux (unlike BSD) 
-- see: https://unix.stackexchange.com/a/63981 --
only passes a single argument to the shebang command
(in this case env or nix-shell).

On the second line, if specified, the interpreter is passed
to nix-shell via the -i flag, so we parse this interpreter
if the second line is specified. If not (nix-shell called w/o
arguments) the implicit interpreter is bash.
-- see also: #127 --


closes #128 

@roberth & @zimbatm might I ask you for a quick review to ensure this implementation is 100% correct? Note: we might need to make sure `nix-shell` cmd is preserved (as a wrapper cmd for this use case) on `nix` 2.0

---

See also the nix manual https://nixos.org/manual/nix/stable/#use-as-a-interpreter

---

There might be additional information in this discussion: https://discourse.nixos.org/t/identify-nix-shell-shebangs-for-pre-commit/8888