### PR TITLE
Add 'txsprofile'->'ini' to 'extensions.py'

### DIFF
--- a/identify/extensions.py
+++ b/identify/extensions.py
@@ -173,6 +173,7 @@ EXTENSIONS = {
     'ts': {'text', 'ts'},
     'tsx': {'text', 'tsx'},
     'ttf': {'binary', 'ttf'},
+    'txsprofile': {'text', 'ini', 'txsprofile'},
     'txt': {'text', 'plain-text'},
     'v': {'text', 'verilog'},
     'vdx': {'text', 'vdx'},


### PR DESCRIPTION
`txsprofile` is an `ini` file used by TeXstudio