### PR TITLE
Make the first README example slightly more self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If you have an actual file on disk, you can get the most information possible
 (a superset of all other methods):
 
 ```python
+>>> from identify import identify
 >>> identify.tags_from_path('/path/to/file.py')
 {'file', 'text', 'python', 'non-executable'}
 >>> identify.tags_from_path('/path/to/file-with-shebang')


### PR DESCRIPTION
Saves new users like me who were too lazy to read the README in full from having to hunt down that there's a module within the package that needed importing.